### PR TITLE
Add support for the Microsoft XRef Service

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -32,6 +32,7 @@
       "_appTitle": "docfx seed website",
       "_enableSearch": true
     },
-    "dest": "_site"
+    "dest": "_site",
+    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
   }
 }


### PR DESCRIPTION
Most projects probably want automatic linking to BCL types, so the sample project should do this.